### PR TITLE
Run Storybook stories in Vitest with jsdom

### DIFF
--- a/packages/client/.storybook/vitest.setup.ts
+++ b/packages/client/.storybook/vitest.setup.ts
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { setProjectAnnotations } from '@storybook/react';
 import * as preview from './preview';
 

--- a/packages/client/components/stories.test.tsx
+++ b/packages/client/components/stories.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { composeStories } from '@storybook/react';
+import { render } from '@testing-library/react';
+import { describe, it } from 'vitest';
+
+type StoryModule = Record<string, unknown> & { default?: unknown };
+
+const storyModules = import.meta.glob<StoryModule>('./**/*.stories.tsx', { eager: true });
+
+describe('Storybook stories', () => {
+  Object.entries(storyModules).forEach(([storyPath, storyModule]) => {
+    const meta = storyModule.default;
+    if (!meta) {
+      return;
+    }
+
+    const composed = composeStories(storyModule as any);
+
+    Object.entries(composed).forEach(([storyName, Story]) => {
+      it(`${storyPath} - ${storyName} renders without crashing`, () => {
+        const { unmount } = render(<Story />);
+        unmount();
+      });
+    });
+  });
+});

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,36 +1,14 @@
 // @ts-nocheck
-import { defineConfig, defineProject } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const dirname =
-  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    projects: [
-      defineProject({
-        extends: true,
-        plugins: [
-          storybookTest({
-            configDir: path.join(dirname, '.storybook'),
-            storybookScript: 'yarn storybook --ci'
-          })
-        ],
-        test: {
-          name: 'storybook',
-          browser: {
-            enabled: true,
-            provider: 'playwright',
-            headless: true,
-            instances: [{ browser: 'chromium' }]
-          },
-          setupFiles: ['./.storybook/vitest.setup.ts']
-        }
-      })
-    ]
+    css: true,
+    environment: 'jsdom',
+    globals: true,
+    include: ['**/*.test.{ts,tsx}'],
+    setupFiles: ['./.storybook/vitest.setup.ts']
   }
 });


### PR DESCRIPTION
## Summary
- configure Vitest to run in a jsdom environment instead of Playwright
- add a shared test that renders every Storybook story to verify it mounts cleanly
- load jest-dom matchers during Vitest setup for Storybook parity

## Testing
- yarn workspace @slowpost/client test
- yarn workspace @slowpost/client build
- yarn workspace @slowpost/client lint


------
https://chatgpt.com/codex/tasks/task_e_68e20829f4a08331adcbb310e26dd8bf