### PR TITLE
Persist login session cookie and unify auth state

### DIFF
--- a/packages/client/lib/auth.tsx
+++ b/packages/client/lib/auth.tsx
@@ -1,0 +1,71 @@
+import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+type AuthState = {
+  isLoggedIn: boolean;
+  username?: string;
+};
+
+type AuthContextValue = {
+  isLoggedIn: boolean;
+  username?: string;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  setSession: (state: AuthState) => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+async function fetchSession(): Promise<AuthState> {
+  try {
+    const response = await fetch('/api/login/session', { credentials: 'include' });
+    if (!response.ok) {
+      throw new Error('Unable to fetch session');
+    }
+    const data = (await response.json()) as { isLoggedIn?: boolean; username?: string };
+    return { isLoggedIn: Boolean(data.isLoggedIn), username: data.username };
+  } catch {
+    return { isLoggedIn: false };
+  }
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthState>({ isLoggedIn: false });
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const session = await fetchSession();
+    setState(session);
+    setLoading(false);
+  }, []);
+
+  const setSession = useCallback((value: AuthState) => {
+    setState(value);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      isLoggedIn: state.isLoggedIn,
+      username: state.username,
+      loading,
+      refresh,
+      setSession
+    }),
+    [loading, refresh, setSession, state.isLoggedIn, state.username]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/packages/client/pages/_app.tsx
+++ b/packages/client/pages/_app.tsx
@@ -1,17 +1,25 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 import StatusBar from '../components/StatusBar';
+import { AuthProvider, useAuth } from '../lib/auth';
 
-export default function SlowpostApp({ Component, pageProps }: AppProps) {
-  const { viewer } = pageProps as { viewer?: { username?: string } };
-  const isLoggedIn = Boolean(viewer?.username);
+function AppLayout({ Component, pageProps }: AppProps) {
+  const { isLoggedIn, username } = useAuth();
 
   return (
     <>
-      <StatusBar isLoggedIn={isLoggedIn} username={viewer?.username} />
+      <StatusBar isLoggedIn={isLoggedIn} username={username} />
       <main>
         <Component {...pageProps} />
       </main>
     </>
+  );
+}
+
+export default function SlowpostApp(appProps: AppProps) {
+  return (
+    <AuthProvider>
+      <AppLayout {...appProps} />
+    </AuthProvider>
   );
 }

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -1,9 +1,11 @@
 import Head from 'next/head';
 import Link from 'next/link';
 import { FollowerList } from '../components/FollowerList';
-import { sampleHome, sampleProfile } from '../lib/data';
+import { useAuth } from '../lib/auth';
+import { sampleHome } from '../lib/data';
 
-export default function HomePage({ isLoggedIn }: { isLoggedIn: boolean }) {
+export default function HomePage() {
+  const { isLoggedIn } = useAuth();
   return (
     <>
       <Head>
@@ -29,13 +31,4 @@ export default function HomePage({ isLoggedIn }: { isLoggedIn: boolean }) {
       )}
     </>
   );
-}
-
-export function getStaticProps() {
-  return {
-    props: {
-      isLoggedIn: true,
-      viewer: { username: sampleProfile.username }
-    }
-  };
 }

--- a/packages/client/pages/p/login.tsx
+++ b/packages/client/pages/p/login.tsx
@@ -1,5 +1,18 @@
+import { useRouter } from 'next/router';
 import LoginFlow from '../../components/LoginFlow';
+import { useAuth } from '../../lib/auth';
 
 export default function LoginPage() {
-  return <LoginFlow />;
+  const router = useRouter();
+  const { refresh, setSession } = useAuth();
+
+  return (
+    <LoginFlow
+      onComplete={async (username) => {
+        setSession({ isLoggedIn: true, username });
+        await refresh();
+        await router.push('/');
+      }}
+    />
+  );
 }

--- a/packages/server/src/datastore.ts
+++ b/packages/server/src/datastore.ts
@@ -266,6 +266,7 @@ export class InMemoryStore {
     if (existing) {
       existing.pin = pin;
       existing.verified = false;
+      existing.loginToken = undefined;
       return existing;
     }
     const username = email.split('@')[0];
@@ -292,6 +293,16 @@ export class InMemoryStore {
     const newSession = this.createLoginSession(email);
     newSession.verified = true;
     return newSession;
+  }
+
+  issueLoginToken(session: LoginSession): string {
+    const token = randomBytes(16).toString('hex');
+    session.loginToken = token;
+    return token;
+  }
+
+  findSessionByToken(token: string): Optional<LoginSession> {
+    return this.sessions.find((record) => record.loginToken === token && record.verified);
   }
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -32,6 +32,7 @@ export interface LoginSession {
   username: string;
   pin: string;
   verified: boolean;
+  loginToken?: string;
 }
 
 export interface HomeFollower {


### PR DESCRIPTION
## Summary
- issue and store login tokens in the API, set them as HTTP-only cookies, and expose a session lookup endpoint
- add a shared auth context in the client so the status bar and pages read the same login state
- enhance the login flow UI with a confirmation step, a dev skip button on the email screen, and credentialed requests

## Testing
- yarn workspace @slowpost/server test
- yarn workspace @slowpost/client test

------
https://chatgpt.com/codex/tasks/task_e_68e21824a8a4833183967f33ad4a2149