### PR TITLE
Add AWS deployment automation and documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.git
+.next
+packages/client/.next
+packages/client/out
+packages/server/dist
+dist
+coverage
+*.log
+tmp
+.turbo
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This repository is organised as a Yarn workspaces monorepo:
 * `packages/server` contains a TypeScript Express API with an in-memory datastore that mirrors the product design in `docs/overview.md`.
 * `packages/client` contains a Next.js app with React components and Storybook stories for each screen described in the overview.
 
+## Deployment
+
+Follow the AWS-specific instructions in [`docs/deployment.md`](docs/deployment.md) to provision the infrastructure and export the required environment variables. Once configured, ship a new release with a single command:
+
+```bash
+yarn deploy
+```
+
 ### Useful commands
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,185 @@
+# Production Deployment Guide (AWS)
+
+This guide describes the exact steps required to deploy Slowpost to Amazon Web Services using Elastic Container Service (ECS) on Fargate. The deployment runs two containers—one for the public Next.js site and one for the Express API—behind an Application Load Balancer (ALB) that routes `/api/*` traffic to the API container.
+
+## Architecture overview
+
+- **Container images**: Pushed to Amazon Elastic Container Registry (ECR) repositories `slowpost-web` and `slowpost-api`.
+- **Compute**: AWS Fargate tasks in an ECS service with two containers in the same task definition so that the API and web tiers share the task lifecycle.
+- **Networking**: Application Load Balancer with path-based routing rules. `/*` forwards to the web target group (port 3000) and `/api/*` forwards to the API target group (port 3001).
+- **Secrets**: Postmark credentials and any other runtime secrets are stored in AWS Secrets Manager or Systems Manager Parameter Store and injected into the task definition as environment variables.
+
+## Prerequisites
+
+1. AWS CLI v2 installed and authenticated (IAM user or role with permissions for ECR and ECS).
+2. Docker CLI available locally to build the container images.
+3. Node.js 20.x and Yarn Classic (1.x) installed locally or on your CI runner.
+4. An AWS account with a VPC, subnets, and security groups suitable for running Fargate tasks behind an ALB.
+
+## 1. One-time AWS infrastructure setup
+
+Perform these actions once per environment (e.g., staging, production).
+
+### 1.1 Create ECR repositories
+
+```bash
+aws ecr create-repository --repository-name slowpost-web --image-scanning-configuration scanOnPush=true
+aws ecr create-repository --repository-name slowpost-api --image-scanning-configuration scanOnPush=true
+```
+
+Take note of your AWS account ID and region; the resulting image URIs follow the pattern `ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/slowpost-web`.
+
+### 1.2 Store secrets
+
+Create secrets for the API credentials (replace the sample values with your own):
+
+```bash
+aws secretsmanager create-secret \
+  --name slowpost/postmark \
+  --secret-string '{"POSTMARK_SERVER_TOKEN":"your-token","POSTMARK_FROM_EMAIL":"no-reply@example.com"}'
+```
+
+Alternatively, store individual keys in Systems Manager Parameter Store and mark them as `SecureString` values.
+
+### 1.3 Define the ECS task
+
+Create an ECS task definition with two containers. The snippet below shows the critical sections; adjust VPC and logging configuration as needed. Replace `{{ACCOUNT_ID}}` and `{{REGION}}` with your values.
+
+```json
+{
+  "family": "slowpost-app",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "1024",
+  "memory": "2048",
+  "networkMode": "awsvpc",
+  "executionRoleArn": "arn:aws:iam::{{ACCOUNT_ID}}:role/ecsTaskExecutionRole",
+  "taskRoleArn": "arn:aws:iam::{{ACCOUNT_ID}}:role/slowpostTaskRole",
+  "containerDefinitions": [
+    {
+      "name": "web",
+      "image": "{{ACCOUNT_ID}}.dkr.ecr.{{REGION}}.amazonaws.com/slowpost-web:latest",
+      "portMappings": [{ "containerPort": 3000 }],
+      "environment": [
+        { "name": "NODE_ENV", "value": "production" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/slowpost",
+          "awslogs-region": "{{REGION}}",
+          "awslogs-stream-prefix": "web"
+        }
+      }
+    },
+    {
+      "name": "api",
+      "image": "{{ACCOUNT_ID}}.dkr.ecr.{{REGION}}.amazonaws.com/slowpost-api:latest",
+      "portMappings": [{ "containerPort": 3001 }],
+      "environment": [
+        { "name": "NODE_ENV", "value": "production" }
+      ],
+      "secrets": [
+        {
+          "name": "POSTMARK_SERVER_TOKEN",
+          "valueFrom": "arn:aws:secretsmanager:{{REGION}}:{{ACCOUNT_ID}}:secret:slowpost/postmark:POSTMARK_SERVER_TOKEN::"
+        },
+        {
+          "name": "POSTMARK_FROM_EMAIL",
+          "valueFrom": "arn:aws:secretsmanager:{{REGION}}:{{ACCOUNT_ID}}:secret:slowpost/postmark:POSTMARK_FROM_EMAIL::"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/slowpost",
+          "awslogs-region": "{{REGION}}",
+          "awslogs-stream-prefix": "api"
+        }
+      }
+    }
+  ]
+}
+```
+
+Register the task definition:
+
+```bash
+aws ecs register-task-definition --cli-input-json file://task-definition.json
+```
+
+### 1.4 Create the ECS service and load balancer
+
+1. Create an Application Load Balancer with two target groups: one for port 3000 (`web`) and another for port 3001 (`api`).
+2. Configure listener rules so that `/api/*` traffic forwards to the API target group and all other paths forward to the web target group.
+3. Create an ECS service (e.g., `slowpost-app`) in your cluster that uses the `slowpost-app` task definition, attaches both target groups, and runs at least two tasks for redundancy.
+
+Once this setup is complete, the service will pull whatever image tags you publish to ECR (defaulting to `latest`).
+
+## 2. Prepare environment variables for `yarn deploy`
+
+Export the variables below in your shell or CI job before running the deployment script:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `AWS_REGION` | Yes | Region that hosts your ECR repositories and ECS cluster. |
+| `AWS_ACCOUNT_ID` | Yes | 12-digit AWS account ID used in the ECR registry domain. |
+| `SLOWPOST_WEB_ECR_REPOSITORY` | Yes | Name of the ECR repository for the web container (e.g., `slowpost-web`). |
+| `SLOWPOST_API_ECR_REPOSITORY` | Yes | Name of the ECR repository for the API container (e.g., `slowpost-api`). |
+| `SLOWPOST_ECS_CLUSTER` | Yes | Name of the ECS cluster that hosts the Slowpost service. |
+| `SLOWPOST_ECS_SERVICE` | Yes | Name of the ECS service to update (e.g., `slowpost-app`). |
+| `AWS_PROFILE` | No | If you use a named AWS CLI profile, set it here so the deploy script reuses it. |
+| `IMAGE_TAG` | No | Custom image tag. Defaults to the short Git commit hash when omitted. |
+
+Example shell setup:
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCOUNT_ID=123456789012
+export SLOWPOST_WEB_ECR_REPOSITORY=slowpost-web
+export SLOWPOST_API_ECR_REPOSITORY=slowpost-api
+export SLOWPOST_ECS_CLUSTER=slowpost-production
+export SLOWPOST_ECS_SERVICE=slowpost-app
+export AWS_PROFILE=slowpost-prod
+export IMAGE_TAG=$(git rev-parse --short HEAD)
+```
+
+Ensure that your AWS credentials grant permissions for `ecr:*` and `ecs:*` actions used by the script.
+
+## 3. Deploy with Yarn
+
+Run the deployment script from the repository root:
+
+```bash
+yarn deploy
+```
+
+The script performs the following actions:
+
+1. Verifies Docker and the AWS CLI are available and that all required environment variables are set.
+2. Installs dependencies and builds both the API and web workspaces.
+3. Builds Docker images using `packages/server/Dockerfile` and `packages/client/Dockerfile`.
+4. Tags each image with both `:latest` and the resolved `IMAGE_TAG` value, authenticates to ECR, and pushes the tags.
+5. Forces a new deployment on the specified ECS service so that it pulls the freshly pushed images.
+
+If any required environment variable is missing, the script exits immediately with a warning so you can correct the configuration before images are built or pushed.
+
+## 4. Verify the release
+
+After `yarn deploy` completes, wait for ECS to replace the tasks. You can monitor progress with:
+
+```bash
+aws ecs describe-services \
+  --cluster "$SLOWPOST_ECS_CLUSTER" \
+  --services "$SLOWPOST_ECS_SERVICE" \
+  ${AWS_PROFILE:+--profile $AWS_PROFILE} \
+  --region "$AWS_REGION" \
+  --query 'services[0].deployments'
+```
+
+When only one primary deployment remains and all tasks are `RUNNING`, perform the following checks:
+
+1. Visit the ALB URL or your custom domain to confirm the Next.js site loads.
+2. Issue a request to `/api/home/ada` (replace `ada` with a seeded username) to confirm the API responds with HTTP 200.
+3. Trigger a login to confirm Postmark emails are delivered. Watch CloudWatch Logs for the `api` stream for any Postmark errors.
+
+Following these steps yields a repeatable production deployment on AWS managed entirely through the `yarn deploy` command and the supporting infrastructure configured above.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "test": "yarn workspace @slowpost/server test && yarn workspace @slowpost/client test",
-    "dev": "mprocs"
+    "dev": "mprocs",
+    "deploy": "node scripts/deploy-aws.js"
   },
   "devDependencies": {
     "vitest": "^1.6.1"

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.4
+
+FROM node:20-bullseye-slim AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json yarn.lock ./
+COPY packages/client/package.json ./packages/client/package.json
+COPY packages/server/package.json ./packages/server/package.json
+RUN yarn install --frozen-lockfile
+
+FROM deps AS builder
+COPY . .
+RUN yarn workspace @slowpost/client build
+
+FROM base AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
+COPY --from=builder /app/packages ./packages
+COPY --from=deps /app/node_modules ./node_modules
+
+EXPOSE 3000
+
+CMD ["yarn", "workspace", "@slowpost/client", "start"]

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.4
+
+FROM node:20-bullseye-slim AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json yarn.lock ./
+COPY packages/server/package.json ./packages/server/package.json
+RUN yarn install --frozen-lockfile
+
+FROM deps AS builder
+COPY . .
+RUN yarn workspace @slowpost/server build
+
+FROM base AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
+COPY --from=builder /app/packages/server/dist ./packages/server/dist
+COPY --from=builder /app/packages/server/package.json ./packages/server/package.json
+COPY --from=deps /app/node_modules ./node_modules
+
+EXPOSE 3001
+
+CMD ["node", "packages/server/dist/devServer.js"]

--- a/scripts/deploy-aws.js
+++ b/scripts/deploy-aws.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/*
+ * Slowpost AWS deployment helper
+ */
+
+'use strict';
+
+const { execSync } = require('child_process');
+
+const REQUIRED_ENV = [
+  'AWS_REGION',
+  'AWS_ACCOUNT_ID',
+  'SLOWPOST_WEB_ECR_REPOSITORY',
+  'SLOWPOST_API_ECR_REPOSITORY',
+  'SLOWPOST_ECS_CLUSTER',
+  'SLOWPOST_ECS_SERVICE'
+];
+
+const missing = REQUIRED_ENV.filter((name) => !process.env[name]);
+
+if (missing.length > 0) {
+  console.error(
+    `[deploy] Missing required environment variables: ${missing.join(', ')}. ` +
+      'Please export them before running `yarn deploy`.'
+  );
+  process.exit(1);
+}
+
+const region = process.env.AWS_REGION;
+const accountId = process.env.AWS_ACCOUNT_ID;
+const webRepo = process.env.SLOWPOST_WEB_ECR_REPOSITORY;
+const apiRepo = process.env.SLOWPOST_API_ECR_REPOSITORY;
+const cluster = process.env.SLOWPOST_ECS_CLUSTER;
+const service = process.env.SLOWPOST_ECS_SERVICE;
+const profile = process.env.AWS_PROFILE;
+
+const awsCli = profile ? `aws --profile ${profile}` : 'aws';
+const ecrRegistry = `${accountId}.dkr.ecr.${region}.amazonaws.com`;
+
+let imageTag = process.env.IMAGE_TAG;
+
+if (!imageTag) {
+  try {
+    imageTag = execSync('git rev-parse --short HEAD').toString().trim();
+  } catch (error) {
+    imageTag = `deploy-${Date.now()}`;
+    console.warn(
+      `[deploy] Could not determine git commit hash. Falling back to generated tag ${imageTag}.`
+    );
+  }
+}
+
+function ensureCli(name, command) {
+  try {
+    execSync(command, { stdio: 'ignore' });
+  } catch (error) {
+    console.error(`[deploy] ${name} is required but was not found on PATH.`);
+    process.exit(1);
+  }
+}
+
+function run(command) {
+  console.log(`\n[deploy] ${command}`);
+  execSync(command, { stdio: 'inherit' });
+}
+
+ensureCli('Docker', 'docker --version');
+ensureCli('AWS CLI v2', 'aws --version');
+
+console.log('[deploy] Starting AWS deployment for Slowpost.');
+console.log(`[deploy] Using AWS region ${region}.`);
+if (profile) {
+  console.log(`[deploy] Using AWS named profile ${profile}.`);
+}
+console.log(`[deploy] Image tag: ${imageTag}`);
+
+const webImage = `${ecrRegistry}/${webRepo}`;
+const apiImage = `${ecrRegistry}/${apiRepo}`;
+
+run('yarn install --frozen-lockfile');
+run('yarn workspace @slowpost/server build');
+run('yarn workspace @slowpost/client build');
+
+run(`docker build -f packages/client/Dockerfile -t ${webImage}:${imageTag} -t ${webImage}:latest .`);
+run(`docker build -f packages/server/Dockerfile -t ${apiImage}:${imageTag} -t ${apiImage}:latest .`);
+
+run(
+  `${awsCli} ecr get-login-password --region ${region} | ` +
+    `docker login --username AWS --password-stdin ${ecrRegistry}`
+);
+
+run(`docker push ${webImage}:${imageTag}`);
+run(`docker push ${webImage}:latest`);
+run(`docker push ${apiImage}:${imageTag}`);
+run(`docker push ${apiImage}:latest`);
+
+run(
+  `${awsCli} ecs update-service ` +
+    `--cluster ${cluster} ` +
+    `--service ${service} ` +
+    `--force-new-deployment ` +
+    `--region ${region}`
+);
+
+console.log('\n[deploy] Deployment request submitted. ECS will roll out the new task definition using the freshly pushed images.');


### PR DESCRIPTION
## Summary
- replace the deployment guide with an AWS ECS playbook and environment variable guidance
- add Dockerfiles and a repository-level .dockerignore so the web and API containers can be built for AWS
- add a `yarn deploy` script that builds, pushes, and rolls out the images via ECS and document it in the README

## Testing
- not run (deployment automation only)


------
https://chatgpt.com/codex/tasks/task_e_68e21b4c0e048331b3e4dd98603560fe