### PR TITLE
Document mprocs tasks and fix Mongo watcher types

### DIFF
--- a/docs/mprocs.md
+++ b/docs/mprocs.md
@@ -1,0 +1,47 @@
+# `mprocs` task overview
+
+The `yarn dev` script at the repository root launches [`mprocs`](https://github.com/pvolok/mprocs) with the configuration in `mprocs.yaml`. The supervisor starts multiple long-lived processes that cooperate to run the Slowpost development stack. The sections below explain what each task does and how they work together.
+
+## Client
+- **Command:** `yarn dev` (run from `packages/client`).
+- **What it does:** boots the Next.js development server for the Slowpost web client, with hot module replacement and lint/type checking handled by Next.
+- **How it integrates:** the client proxies API traffic to the Express server started by the `server-run` task. It reads environment variables from `.env.local` or the shell to determine API endpoints.
+
+## Data type watcher (`data-types`)
+- **Command:** `yarn tsc --watch --preserveWatchOutput` (run from `packages/data`).
+- **What it does:** continuously compiles the shared data models and store implementation to `packages/data/dist`. The generated declaration files provide type information for the server and Mongo packages.
+- **How it integrates:** updates from this watcher are consumed by the `server-types` and `mongo-types` watchers through TypeScript path mapping. Because TypeScript now resolves `@slowpost/data` directly to the source files, the watcher immediately reflects cross-package changes without waiting for a manual build.
+
+## Mongo type watcher (`mongo-types`)
+- **Command:** `yarn tsc --watch --preserveWatchOutput` (run from `packages/mongo`).
+- **What it does:** compiles the MongoDB integration layer, emitting JavaScript and declarations to `packages/mongo/dist`.
+- **How it integrates:**
+  - Waits for the shared data and server sources via the TypeScript path mappings defined in `packages/mongo/tsconfig.json`.
+  - Produces `dist/src/devMemory.js` and `dist/src/runServer.js`, which are required by the `mongo-memory` and `server-run` tasks. Those tasks block until the compiled files exist, so they start automatically after the first successful emit.
+
+## Server type watcher (`server-types`)
+- **Command:** `yarn tsc --watch --preserveWatchOutput` (run from `packages/server`).
+- **What it does:** watches and compiles the Express API server into `packages/server/dist`.
+- **How it integrates:** exposes the `createServer` factory and type declarations that `packages/mongo` consumes. Like the Mongo watcher, it relies on TypeScript path mappings to pull from the shared data source directly.
+
+## In-memory MongoDB (`mongo-memory`)
+- **Command:** `node dist/src/devMemory.js` (run from `packages/mongo`, after waiting for the compiled file).
+- **What it does:** starts `mongodb-memory-server` on `mongodb://127.0.0.1:37017` (or a custom port from `MONGODB_MEMORY_PORT`). The database is seeded with the standard dataset defined in `@slowpost/data` so that development logins and groups are immediately available.
+- **How it integrates:**
+  - The task blocks until `mongo-types` produces `dist/src/devMemory.js`.
+  - The `server-run` task connects to the URI the in-memory server exposes. Shared defaults ensure both processes use the same database name and port unless overridden via environment variables.
+
+## API server (`server-run`)
+- **Command:** `node --watch dist/src/runServer.js` (run from `packages/mongo`, after waiting for the compiled file) with `MONGODB_URI=mongodb://127.0.0.1:37017` and `MONGODB_DB=slowpost-dev`.
+- **What it does:** launches the Slowpost Express API using the Mongo-backed store. `node --watch` reloads the compiled file whenever the TypeScript watcher re-emits.
+- **How it integrates:**
+  - Waits for `mongo-types` to emit `dist/src/runServer.js`.
+  - Reads the Mongo connection string from the same environment variables populated by the `mongo-memory` task, so it automatically connects to the in-memory instance.
+  - Provides the API consumed by the client development server.
+
+## Process coordination summary
+- TypeScript watchers (`data-types`, `server-types`, `mongo-types`) run continuously so that source edits trigger recompilation across packages.
+- Runtime tasks (`mongo-memory`, `server-run`, `client`) wait for the compiled output they need before starting, ensuring there are no race conditions.
+- Shared environment defaults (`MONGODB_URI`, `MONGODB_DB`, and `MONGODB_MEMORY_*`) allow the API and database layers to find each other without additional configuration.
+
+With these tasks running, `yarn dev` delivers a fully functional Slowpost stack: a seeded MongoDB instance, the Express API, and the Next.js client—all updating live as you edit the source.

--- a/packages/mongo/src/index.ts
+++ b/packages/mongo/src/index.ts
@@ -13,34 +13,36 @@ import {
   getStandardDataset,
   seedCollections,
   type CollectionLike,
+  type Query,
   type SlowpostCollections,
   type SlowpostStore,
-  type StandardDataset
+  type StandardDataset,
+  type Update
 } from '@slowpost/data';
 
 function wrapCollection<T extends Document>(collection: Collection<T>): CollectionLike<T> {
   return {
-    find(query) {
+    find(query: Query<T>) {
       return {
         toArray: async () => collection.find(query as Filter<T>).toArray() as unknown as T[]
       };
     },
-    findOne(query) {
+    findOne(query: Query<T>) {
       return collection.findOne(query as Filter<T>) as Promise<T | null>;
     },
-    async insertOne(document) {
+    async insertOne(document: T) {
       await collection.insertOne(document as OptionalUnlessRequiredId<T>);
     },
-    async insertMany(documents) {
+    async insertMany(documents: readonly T[]) {
       if (documents.length === 0) {
         return;
       }
       await collection.insertMany(documents as OptionalUnlessRequiredId<T>[]);
     },
-    async updateOne(filter, update) {
+    async updateOne(filter: Query<T>, update: Update<T>) {
       await collection.updateOne(filter as Filter<T>, update as UpdateFilter<T>);
     },
-    async deleteMany(filter) {
+    async deleteMany(filter: Query<T>) {
       await collection.deleteMany(filter as Filter<T>);
     }
   };

--- a/packages/mongo/tsconfig.json
+++ b/packages/mongo/tsconfig.json
@@ -7,6 +7,11 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@slowpost/data": ["../data/src/index.ts"],
+      "@slowpost/server": ["../server/src/index.ts"]
+    },
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true

--- a/packages/server/tests/datastore.test.ts
+++ b/packages/server/tests/datastore.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { createMemoryStore } from '@slowpost/data';
+import { createMemoryStore, type HomeFollower, type Profile } from '@slowpost/data';
 
 describe('Slowpost data store', () => {
   it('generates a home view with followers', async () => {
     const store = createMemoryStore();
     const home = await store.getHomeView('ada');
     expect(home.followers).toHaveLength(2);
-    const followerNames = home.followers.map((follower) => follower.username).sort();
+    const followerNames = home.followers
+      .map((follower: HomeFollower) => follower.username)
+      .sort();
     expect(followerNames).toEqual(['elon', 'grace']);
   });
 
@@ -20,7 +22,9 @@ describe('Slowpost data store', () => {
   it('allows toggling close friend status', async () => {
     const store = createMemoryStore();
     const updated = await store.setCloseFriend('ada', 'elon', true);
-    const elon = updated.followers.find((follower) => follower.username === 'elon');
+    const elon = updated.followers.find(
+      (follower: HomeFollower) => follower.username === 'elon'
+    );
     expect(elon?.isCloseFriend).toBe(true);
   });
 
@@ -35,7 +39,7 @@ describe('Slowpost data store', () => {
     const store = createMemoryStore();
     const group = await store.getGroupView('future-society');
     expect(group.group.isPrivate).toBe(true);
-    expect(group.members.map((member) => member.username)).toContain('grace');
+    expect(group.members.map((member: Profile) => member.username)).toContain('grace');
   });
 
   it('tracks pending follower requests', async () => {

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -7,6 +7,10 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@slowpost/data": ["../data/src/index.ts"]
+    },
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true


### PR DESCRIPTION
## Summary
- document each `mprocs` task and how the processes coordinate during `yarn dev`
- add TypeScript path mappings and stronger typings so the Mongo watcher can emit runtime files
- tighten server tests with explicit type usage to satisfy the stricter compiler settings

## Testing
- yarn workspace @slowpost/server test
- yarn --cwd packages/server tsc --project tsconfig.json --pretty false
- yarn --cwd packages/mongo tsc --project tsconfig.json --pretty false

------
https://chatgpt.com/codex/tasks/task_e_68e2f074f34c833190be6c42d1e600fb