### PR TITLE
Allow dev skip login locally

### DIFF
--- a/packages/client/components/LoginFlow.tsx
+++ b/packages/client/components/LoginFlow.tsx
@@ -149,7 +149,11 @@ export function LoginFlow({ onComplete }: LoginFlowProps) {
       setStatusMessage('PIN skipped for development. Choose a username to finish signing in.');
       setStep('username');
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'Unable to skip the PIN in development mode.');
+      if (error instanceof Error && /not found/i.test(error.message)) {
+        setErrorMessage('Skipping the PIN is only available when Slowpost is running locally.');
+      } else {
+        setErrorMessage(error instanceof Error ? error.message : 'Unable to skip the PIN in development mode.');
+      }
     } finally {
       setSkippingPin(false);
     }

--- a/packages/client/components/__tests__/LoginFlow.stories.tsx
+++ b/packages/client/components/__tests__/LoginFlow.stories.tsx
@@ -48,3 +48,46 @@ export const Default: Story = {
     await waitFor(() => expect(onCompleteSpy.calls).toContainEqual(['ada']));
   }
 };
+
+export const SkipPinFromEmailStep: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    onCompleteSpy.calls.length = 0;
+
+    const emailInput = canvas.getByLabelText(/email address/i);
+    await userEvent.clear(emailInput);
+    await userEvent.type(emailInput, 'local-new@slowpost.org');
+
+    const skipButton = await canvas.findByRole('button', { name: /skip pin/i });
+    await userEvent.click(skipButton);
+
+    const usernameInput = await canvas.findByLabelText(/choose a username/i);
+    expect(usernameInput).toHaveValue('local-new');
+    await userEvent.type(usernameInput, '{enter}');
+
+    await waitFor(() => expect(onCompleteSpy.calls).toContainEqual(['local-new']));
+  }
+};
+
+export const SkipPinAfterRequestingPin: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    onCompleteSpy.calls.length = 0;
+
+    const emailInput = canvas.getByLabelText(/email address/i);
+    await userEvent.clear(emailInput);
+    await userEvent.type(emailInput, 'grace@example.com{enter}');
+
+    const enterPinButton = await canvas.findByRole('button', { name: /enter pin/i });
+    await userEvent.click(enterPinButton);
+
+    const skipButton = await canvas.findByRole('button', { name: /skip pin/i });
+    await userEvent.click(skipButton);
+
+    const usernameInput = await canvas.findByLabelText(/choose a username/i);
+    expect(usernameInput).toHaveValue('grace');
+    await userEvent.type(usernameInput, '{enter}');
+
+    await waitFor(() => expect(onCompleteSpy.calls).toContainEqual(['grace']));
+  }
+};

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -23,6 +23,68 @@ const loginCookieOptions: CookieOptions = {
 type SessionSnapshot = Pick<LoginSession, 'username' | 'email'>;
 const loginTokens = new Map<string, SessionSnapshot>();
 
+const localHostnames = new Set(['localhost', '127.0.0.1', '::1']);
+const localIpAddresses = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+function normalizeHost(value: string): string | undefined {
+  try {
+    const url = new URL(value);
+    return url.hostname.toLowerCase();
+  } catch {
+    const [host] = value.split(':');
+    return host.toLowerCase();
+  }
+}
+
+function isLocalHostname(value: string | undefined | null): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = normalizeHost(value.trim());
+  if (!normalized) {
+    return false;
+  }
+  return localHostnames.has(normalized);
+}
+
+function isLocalAddress(value: string | undefined | null): boolean {
+  if (!value) {
+    return false;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const normalized = trimmed.startsWith('::ffff:') ? trimmed.slice('::ffff:'.length) : trimmed;
+  return localIpAddresses.has(normalized);
+}
+
+function requestFromLocalEnvironment(req: Request): boolean {
+  if (isLocalHostname(req.hostname)) {
+    return true;
+  }
+
+  const forwardedHost = req.get('x-forwarded-host');
+  if (forwardedHost && forwardedHost.split(',').some((candidate) => isLocalHostname(candidate))) {
+    return true;
+  }
+
+  const origin = req.get('origin');
+  if (origin && isLocalHostname(origin)) {
+    return true;
+  }
+
+  const forwardedFor = req.get('x-forwarded-for');
+  if (forwardedFor) {
+    const forwardedIps = forwardedFor.split(',');
+    if (forwardedIps.some((ip) => isLocalAddress(ip))) {
+      return true;
+    }
+  }
+
+  return isLocalAddress(req.ip);
+}
+
 if (!isDev && !postmarkServerToken) {
   console.warn('POSTMARK_SERVER_TOKEN is not set. Login emails will fail until it is configured.');
 }
@@ -199,7 +261,7 @@ export function createServer(dataStore: SlowpostStore = store) {
   });
 
   app.post('/api/login/dev-skip', async (req, res) => {
-    if (!isDev) {
+    if (!isDev && !requestFromLocalEnvironment(req)) {
       res.status(404).json({ message: 'Not found' });
       return;
     }

--- a/packages/server/tests/loginRoutes.test.ts
+++ b/packages/server/tests/loginRoutes.test.ts
@@ -1,0 +1,93 @@
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createMemoryStore } from '@slowpost/data';
+
+type TestServer = {
+  baseUrl: string;
+  close(): Promise<void>;
+};
+
+async function startServer(nodeEnv: string): Promise<TestServer> {
+  const originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = nodeEnv;
+  vi.resetModules();
+  const { createServer } = await import('../src/server.js');
+  const app = createServer(createMemoryStore());
+
+  const server = await new Promise<Server>((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    baseUrl,
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      process.env.NODE_ENV = originalNodeEnv;
+      vi.resetModules();
+    }
+  };
+}
+
+describe('POST /api/login/dev-skip', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('allows skipping the PIN locally even when NODE_ENV=production', async () => {
+    const server = await startServer('production');
+    try {
+      const response = await fetch(`${server.baseUrl}/api/login/dev-skip`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'http://localhost:3000'
+        },
+        body: JSON.stringify({ email: 'new-dev@slowpost.org' })
+      });
+
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as { username?: string };
+      expect(payload.username).toBe('new-dev');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('reuses existing login sessions when skipping the PIN', async () => {
+    const server = await startServer('production');
+    try {
+      const email = 'grace@example.com';
+      const firstResponse = await fetch(`${server.baseUrl}/api/login/dev-skip`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'http://localhost:3000'
+        },
+        body: JSON.stringify({ email })
+      });
+
+      expect(firstResponse.status).toBe(200);
+      const firstPayload = (await firstResponse.json()) as { username?: string };
+      expect(firstPayload.username).toBe('grace');
+
+      const secondResponse = await fetch(`${server.baseUrl}/api/login/dev-skip`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'http://localhost:3000'
+        },
+        body: JSON.stringify({ email })
+      });
+
+      expect(secondResponse.status).toBe(200);
+      const secondPayload = (await secondResponse.json()) as { username?: string };
+      expect(secondPayload.username).toBe('grace');
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow the /api/login/dev-skip route when requests originate from localhost even if NODE_ENV is production
- add regression coverage to confirm skipping the PIN works for both new and existing login sessions
- update the client login flow stories and messaging to cover the skip-PIN paths

## Testing
- yarn workspace @slowpost/server test
- yarn workspace @slowpost/client test
- yarn workspace @slowpost/client build
- yarn workspace @slowpost/client storybook (fails: attempts to open a browser in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e2f1c98f00833193df3cefcad3ff1f