### PR TITLE
Add root build and typecheck scripts for all workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "yarn workspaces foreach --all --topological-dev run build",
+    "typecheck": "yarn workspaces foreach --all --topological-dev run typecheck",
     "test": "yarn workspace @slowpost/server test && yarn workspace @slowpost/client test",
     "dev": "mprocs",
     "deploy": "node scripts/deploy-aws.js"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -5,7 +5,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prebuild": "yarn workspace @slowpost/server build",
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "dev:mongo": "node dist/src/devMemory.js",
     "dev:server": "node dist/src/runServer.js"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prebuild": "yarn workspace @slowpost/data build",
     "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "pretest": "yarn workspace @slowpost/data build",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary
- add root scripts that fan out build and typecheck across all workspaces
- add tsc-based typecheck scripts to every TypeScript package

## Testing
- yarn typecheck
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e2f55145b88331b31baefeab9115d5