### PR TITLE
Fix form control overflow inside cards

### DIFF
--- a/packages/client/style/system.module.css
+++ b/packages/client/style/system.module.css
@@ -5,6 +5,7 @@
   border-radius: 1rem;
   border: none;
   box-shadow: none;
+  box-sizing: border-box;
   color: #0b1f38;
   display: block;
   margin: var(--card-margin) auto;
@@ -93,6 +94,7 @@
 .padBox {
   --pad-vert: 0;
   --pad-horiz: 0;
+  box-sizing: border-box;
   padding: var(--pad-vert) var(--pad-horiz);
   width: 100%;
 }
@@ -234,6 +236,7 @@
 .textarea {
   border: 1px solid #0b1f38;
   border-radius: 0.625rem;
+  box-sizing: border-box;
   font-size: 1rem;
   padding: 0.75rem 1rem;
   width: 100%;


### PR DESCRIPTION
## Summary
- add border-box sizing to shared input and textarea styles so padding and borders stay within card width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21b208a6883319aa9b3c4ba4d10c5