### PR TITLE
Handle IPv6 localhost requests for dev skip

### DIFF
--- a/packages/server/tests/loginRoutes.test.ts
+++ b/packages/server/tests/loginRoutes.test.ts
@@ -1,19 +1,28 @@
 import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
+import { request as httpRequest } from 'node:http';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { createMemoryStore } from '@slowpost/data';
+
+type StartServerOptions = {
+  trustProxy?: boolean;
+};
 
 type TestServer = {
   baseUrl: string;
   close(): Promise<void>;
 };
 
-async function startServer(nodeEnv: string): Promise<TestServer> {
+async function startServer(nodeEnv: string, options: StartServerOptions = {}): Promise<TestServer> {
   const originalNodeEnv = process.env.NODE_ENV;
   process.env.NODE_ENV = nodeEnv;
   vi.resetModules();
   const { createServer } = await import('../src/server.js');
   const app = createServer(createMemoryStore());
+
+  if (options.trustProxy) {
+    app.set('trust proxy', true);
+  }
 
   const server = await new Promise<Server>((resolve) => {
     const instance = app.listen(0, () => resolve(instance));
@@ -86,6 +95,49 @@ describe('POST /api/login/dev-skip', () => {
       expect(secondResponse.status).toBe(200);
       const secondPayload = (await secondResponse.json()) as { username?: string };
       expect(secondPayload.username).toBe('grace');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('allows skipping the PIN when proxied from an IPv6 localhost origin', async () => {
+    const server = await startServer('production', { trustProxy: true });
+    try {
+      const url = new URL('/api/login/dev-skip', server.baseUrl);
+      const payload = JSON.stringify({ email: 'ada@example.com' });
+
+      const response = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const request = httpRequest(
+          {
+            hostname: url.hostname,
+            port: url.port,
+            method: 'POST',
+            path: url.pathname,
+            headers: {
+              Host: 'api.slowpost.dev',
+              Origin: 'http://[::1]:3000',
+              'X-Forwarded-For': '203.0.113.5',
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(payload)
+            }
+          },
+          (res) => {
+            const chunks: Uint8Array[] = [];
+            res.on('data', (chunk) => chunks.push(chunk));
+            res.on('end', () => {
+              const body = Buffer.concat(chunks).toString('utf8');
+              resolve({ status: res.statusCode ?? 0, body });
+            });
+          }
+        );
+        request.on('error', reject);
+        request.write(payload);
+        request.end();
+      });
+
+      expect(response.status).toBe(200);
+      const payloadJson = JSON.parse(response.body) as { username?: string };
+      expect(payloadJson.username).toBe('ada');
     } finally {
       await server.close();
     }


### PR DESCRIPTION
## Summary
- normalize host detection to properly treat bracketed IPv6 loopback values as local
- extend the dev-skip test harness to simulate proxied IPv6 requests through a trusted proxy
- allow the dev-skip login route to fall back to a signup session when the requested account is missing so local skips keep working

## Testing
- `corepack yarn workspace @slowpost/data build`
- `corepack yarn workspace @slowpost/server test`


------
https://chatgpt.com/codex/tasks/task_e_68e2f8a0ba2c83318ac4fd893a61cb90