### PR TITLE
Handle signup intent when skipping PIN in dev mode

### DIFF
--- a/packages/client/components/LoginFlow.tsx
+++ b/packages/client/components/LoginFlow.tsx
@@ -182,17 +182,21 @@ export function LoginFlow({ onComplete }: LoginFlowProps) {
         await readError(response);
       }
       let suggestedUsername = email.split('@')[0] ?? '';
+      let sessionIntent: Mode = activeIntent;
       try {
-        const payload = (await response.json()) as { username?: string };
+        const payload = (await response.json()) as { username?: string; intent?: Mode };
         if (payload?.username) {
           suggestedUsername = payload.username;
+        }
+        if (payload?.intent === 'login' || payload?.intent === 'signup') {
+          sessionIntent = payload.intent;
         }
       } catch {
         // ignore parsing errors and fall back to the email prefix
       }
       setPin('');
-      if (activeIntent === 'login') {
-        setIntent('login');
+      setIntent(sessionIntent);
+      if (sessionIntent === 'login') {
         onComplete?.(suggestedUsername);
         return;
       }
@@ -200,7 +204,6 @@ export function LoginFlow({ onComplete }: LoginFlowProps) {
       setStatusMessage('PIN skipped for development. Choose a username and add your name to finish creating your account.');
       setStatusKind('success');
       setStep('signupDetails');
-      setIntent('signup');
     } catch (error) {
       if (error instanceof Error && /not found/i.test(error.message)) {
         setErrorMessage('Skipping the PIN is only available when Slowpost is running locally.');

--- a/packages/client/components/__tests__/LoginFlow.stories.tsx
+++ b/packages/client/components/__tests__/LoginFlow.stories.tsx
@@ -143,7 +143,12 @@ export const SkipPinFromEmailStep: Story = {
 
     const usernameInput = await canvas.findByLabelText(/choose a username/i);
     expect(usernameInput).toHaveValue('local-new');
-    await userEvent.type(usernameInput, '{enter}');
+    const nameInput = await canvas.findByLabelText(/your name/i);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'Local New');
+
+    const createAccountButton = canvas.getByRole('button', { name: /create account/i });
+    await userEvent.click(createAccountButton);
 
     await waitFor(() => expect(onCompleteSpy.calls).toContainEqual(['local-new']));
   }
@@ -156,7 +161,7 @@ export const SkipPinAfterRequestingPin: Story = {
 
     const emailInput = canvas.getByLabelText(/email address/i);
     await userEvent.clear(emailInput);
-    await userEvent.type(emailInput, 'grace@example.com{enter}');
+    await userEvent.type(emailInput, 'new-dev@slowpost.org{enter}');
 
     const enterPinButton = await canvas.findByRole('button', { name: /enter pin/i });
     await userEvent.click(enterPinButton);
@@ -165,9 +170,14 @@ export const SkipPinAfterRequestingPin: Story = {
     await userEvent.click(skipButton);
 
     const usernameInput = await canvas.findByLabelText(/choose a username/i);
-    expect(usernameInput).toHaveValue('grace');
-    await userEvent.type(usernameInput, '{enter}');
+    expect(usernameInput).toHaveValue('new-dev');
+    const nameInput = await canvas.findByLabelText(/your name/i);
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'New Dev');
 
-    await waitFor(() => expect(onCompleteSpy.calls).toContainEqual(['grace']));
+    const createAccountButton = canvas.getByRole('button', { name: /create account/i });
+    await userEvent.click(createAccountButton);
+
+    await waitFor(() => expect(onCompleteSpy.calls).toContainEqual(['new-dev']));
   }
 };

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -373,7 +373,7 @@ export function createServer(dataStore: SlowpostStore = store) {
         const token = issueLoginToken({ username: session.username, email: session.email });
         setLoginCookie(res, token);
       }
-      res.json({ username: session.username });
+      res.json({ username: session.username, intent: session.intent });
     } catch (error) {
       res.status(400).json({ message: (error as Error).message });
     }

--- a/packages/server/tests/loginRoutes.test.ts
+++ b/packages/server/tests/loginRoutes.test.ts
@@ -59,8 +59,9 @@ describe('POST /api/login/dev-skip', () => {
       });
 
       expect(response.status).toBe(200);
-      const payload = (await response.json()) as { username?: string };
+      const payload = (await response.json()) as { username?: string; intent?: 'login' | 'signup' };
       expect(payload.username).toBe('new-dev');
+      expect(payload.intent).toBe('signup');
     } finally {
       await server.close();
     }
@@ -80,8 +81,9 @@ describe('POST /api/login/dev-skip', () => {
       });
 
       expect(firstResponse.status).toBe(200);
-      const firstPayload = (await firstResponse.json()) as { username?: string };
+      const firstPayload = (await firstResponse.json()) as { username?: string; intent?: 'login' | 'signup' };
       expect(firstPayload.username).toBe('grace');
+      expect(firstPayload.intent).toBe('login');
 
       const secondResponse = await fetch(`${server.baseUrl}/api/login/dev-skip`, {
         method: 'POST',
@@ -93,8 +95,9 @@ describe('POST /api/login/dev-skip', () => {
       });
 
       expect(secondResponse.status).toBe(200);
-      const secondPayload = (await secondResponse.json()) as { username?: string };
+      const secondPayload = (await secondResponse.json()) as { username?: string; intent?: 'login' | 'signup' };
       expect(secondPayload.username).toBe('grace');
+      expect(secondPayload.intent).toBe('login');
     } finally {
       await server.close();
     }
@@ -136,8 +139,9 @@ describe('POST /api/login/dev-skip', () => {
       });
 
       expect(response.status).toBe(200);
-      const payloadJson = JSON.parse(response.body) as { username?: string };
+      const payloadJson = JSON.parse(response.body) as { username?: string; intent?: 'login' | 'signup' };
       expect(payloadJson.username).toBe('ada');
+      expect(payloadJson.intent).toBe('login');
     } finally {
       await server.close();
     }


### PR DESCRIPTION
## Summary
- include the login session intent in the /api/login/dev-skip response so the client can differentiate login vs signup flows
- teach the LoginFlow dev skip handler and supporting Storybook plays/mocks to drive the signup form when the server falls back to signup

## Testing
- corepack yarn workspace @slowpost/server test
- corepack yarn workspace @slowpost/client test
- corepack yarn workspace @slowpost/client build

------
https://chatgpt.com/codex/tasks/task_e_68e2fe01993c8331a3f06543c1f92191